### PR TITLE
invalid conversion bug removed from runProject function

### DIFF
--- a/src/Parsehub/Parsehub.php
+++ b/src/Parsehub/Parsehub.php
@@ -200,7 +200,7 @@ class Parsehub
         ->send();
 
         if ($this->isResponseValid($response)) {
-            $run_object = json_decode($response->body);
+            $run_object = $response->body;
             // If this is new run then parsehub return complete run object.
             if (isset($run_object->project_token) && isset($run_object->run_token)) {
                 self::$logger->info('Project run successfully on parsehub with values: ', ['context' => array(
@@ -228,7 +228,7 @@ class Parsehub
                     'requestbody_body' => $requestbody,
                 )]);
             }
-            $data = $response->body;
+            $data = json_encode($response->body);
             return $data;
         }
         return $response;


### PR DESCRIPTION

Fatal error: Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, stdClass given in msankhala\parsehub-php\src\Parsehub\Parsehub.php:203